### PR TITLE
Fix missing module unlock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ if sys.version_info[:2] < (3, 5):
 setup(
     name='ssh-unlocker',
     version=__version__,
+    py_modules=['unlock'],
     packages=['unlocker'],
-    package_data={'unlocker': ['unlock.py', 'unlocker/*.py']},
+    package_data={'unlocker': ['unlocker/*.py']},
     entry_points={
         'console_scripts': [
             'ssh-unlocker=unlock:main',


### PR DESCRIPTION
It is possible to install the package. It fails when executed with following error:

```
root@m:/usr/local/ssh-unlocker# python3 -m unlock
Traceback (most recent call last):
  File "/usr/local/bin/ssh-unlocker", line 7, in <module>
    from unlock import main
ImportError: No module named 'unlock'
```

Problem is that file `unlock.py` is missing.