### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 venv/
 .idea/
 ssh_unlocker.egg-info/
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-slim
+
+LABEL maintainer drober+python@gmail.com
+
+WORKDIR /usr/src/app
+VOLUME /usr/src/conf
+ENV SSH_UNLOCK_VERBOSE ""
+
+COPY . .
+RUN pip3 install .
+CMD [ "python", "./unlock.py", "--config", "/usr/src/conf/config.ini"]

--- a/README.Dockerfile.md
+++ b/README.Dockerfile.md
@@ -1,0 +1,19 @@
+# Building a Docker image
+Simply run `./build_docker.sh` with no parameters. It'll create an image called `ssh-unlock:VERSION`
+where VERSION is based on specified version of unlocker library.
+
+If first arg is set it will create `$1:ssh-unlock:VERSION` so you can upload it easier to DockerHub if you want to.
+
+# Running a container
+At this time this Dockerfile is capable of using file configuration only as `config.ini`, which should be mounted in container's `/usr/src/config` directory.
+
+All private keys or configuration must be in this directory and properly referenced in configuration file `config.ini`. Mind that inside container all these files would be in `/usr/src/config/your_expeted_file`. This means that using `ConfigMap` object it could run easily on Kubernetes.
+
+## Docker run example
+`docker run -ti --rm -v $HOME/ssh-unlock/config/:/usr/src/config/ ssh-unlock:0.2`
+
+## Docker run example as daemon
+`docker run -d --name ssh-unlock -v $HOME/ssh-unlock/config/:/usr/src/config/ ssh-unlock:0.2`
+
+## See daemon logs
+`docker logs -f ssh-unlock`

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+UNLOCK_VERSION=${UNLOCK_VERSION:-$(awk -F \' '{if($1="__version__ ="){print $2;exit}}' unlocker/__init__.py)}
+
+if [ ! -z ${UNLOCK_VERSION} ]
+then
+	echo "[$0] No image version specified not obtained from source. Set UNLOCK_VERSION env var to build this"
+	exit 1
+fi
+
+if [ ! -z $1 ]
+then
+	docker build . -t $1/ssh-unlock:${UNLOCK_VERSION}
+else
+	docker build . -t ssh-unlock:${UNLOCK_VERSION}
+fi


### PR DESCRIPTION
Allow users to create and use their own Docker image of this tool.

Builder and README added

Keep in mind that builder is pretty basic as it copies everything in the main directory inside /usr/src/app of docker image.

If you like this, copying specific directories would be not difficult.
